### PR TITLE
Remove Steep::Diagnostic::Ruby::UnsupportedSyntax ignore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -196,7 +196,7 @@ group :development do
   gem 'rbs_rails'
 
   # For type signature lsp
-  gem 'steep'
+  gem 'steep', github: 'soutaro/steep', ref: '56c911bcb660077ea5dd7db9077a0149277b241c'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,27 @@ GIT
     rails-settings-cached (0.6.6)
       rails (>= 4.2.0)
 
+GIT
+  remote: https://github.com/soutaro/steep.git
+  revision: 56c911bcb660077ea5dd7db9077a0149277b241c
+  ref: 56c911bcb660077ea5dd7db9077a0149277b241c
+  specs:
+    steep (1.4.0)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.2.2)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.15, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (>= 3.1.0)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -711,21 +732,6 @@ GEM
       net-ssh (>= 2.8.0)
     stackprof (0.2.25)
     statsd-ruby (1.5.0)
-    steep (1.4.0)
-      activesupport (>= 5.1)
-      concurrent-ruby (>= 1.2.2)
-      csv (>= 3.0.9)
-      fileutils (>= 1.1.0)
-      json (>= 2.1.0)
-      language_server-protocol (>= 3.15, < 4.0)
-      listen (~> 3.0)
-      logger (>= 1.3.0)
-      parser (>= 3.1)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 2.8.0)
-      securerandom (>= 0.1)
-      strscan (>= 1.0.0)
-      terminal-table (>= 2, < 4)
     stoplight (3.0.1)
       redlock (~> 1.0)
     strong_migrations (0.8.0)
@@ -938,7 +944,7 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   sprockets-rails (~> 3.4)
   stackprof
-  steep
+  steep!
   stoplight (~> 3.0.1)
   strong_migrations (~> 0.8)
   thor (~> 1.2)

--- a/Steepfile
+++ b/Steepfile
@@ -42,7 +42,6 @@ ignores = [
   Steep::Diagnostic::Ruby::UnexpectedError,
   Steep::Diagnostic::Ruby::MethodBodyTypeMismatch,
   Steep::Diagnostic::Ruby::ArgumentTypeMismatch,
-  Steep::Diagnostic::Ruby::UnsupportedSyntax,
   Steep::Diagnostic::Ruby::UnexpectedSuper,
   Steep::Diagnostic::Ruby::UnexpectedYield,
   Steep::Diagnostic::Ruby::BreakTypeMismatch,


### PR DESCRIPTION
ref: https://github.com/soutaro/steep/pull/788
ref: https://github.com/soutaro/steep/issues/743
